### PR TITLE
Add the function to its own globals, so recursive functions work

### DIFF
--- a/ipython_doctester.py
+++ b/ipython_doctester.py
@@ -188,6 +188,7 @@ class NoStudentNameException(IPythonDoctesterException):
 
 
 def testobj(func):
+    func.func_globals[func.__name__] = func
     tests = finder.find(func)
     if (not tests) or (not tests[0].examples):
         doctest_filename = os.path.join(os.curdir, doctest_path, func.__name__


### PR DESCRIPTION
Currently, recursive functions don't seem to work, because at the time the doctest is run, the function hasn't actually been defined in its own namespace, so the recursive call fails. This pull request adds the function to its own global namespace, so that when it tries to call itself, the call will succeed.
