### PR TITLE
Use display, rather than publish_display_data

### DIFF
--- a/ipython_doctester.py
+++ b/ipython_doctester.py
@@ -30,7 +30,7 @@ import os.path
 import requests
 
 
-from IPython.core.displaypub import publish_display_data
+from IPython.display import display
 
 try:
     from IPython.zmq import displayhook as zmq_displayhook
@@ -89,11 +89,9 @@ class Reporter(object):
         #     IPython.core.displaypub.publish_pretty(self.txt)
 
         if self.html:
-            publish_display_data("ipython_doctester",
-                                 {'text/html': self._repr_html_()})
+            display({'text/html': self._repr_html_()}, raw=True)
         else:
-            publish_display_data("ipython_doctester",
-                                 {'text/plain': self.txt})
+            display({'text/plain': self.txt}, raw=True)
 
     def _repr_html_(self):
         result = self.fail_template if self.failed else self.success_template


### PR DESCRIPTION
The message spec in IPython was recently updated, and they no longer support `publish_display_data` (see [IPEP 13](https://github.com/ipython/ipython/wiki/IPEP-13%3A-Updating-the-Message-Spec)). In particular, if you use `nbconvert` to convert a notebook that uses the doctester to HTML, the HTML output of "success" (or the failures) doesn't get converted because it's not actually displayed -- this pull request updates the doctester to be in line with IPEP 13, and display the data so that it will work with nbconvert.

The message spec stuff is pretty new, though, so understandable if you want to wait a while before merging this. But I thought I'd go ahead and submit a pull request in case anyone else finds this change useful.
